### PR TITLE
highlight differences in dtdcompare report

### DIFF
--- a/xslt/dtdcompare.xsl
+++ b/xslt/dtdcompare.xsl
@@ -295,6 +295,7 @@
                            <ul>
                               <xsl:apply-templates select="$dtd1-attributes">
                                  <xsl:with-param name="compare" select="$dtd2-attributes"/>
+                                 <xsl:sort select="../@name"/>
                               </xsl:apply-templates>
                            </ul>
                         </xsl:when>
@@ -310,6 +311,7 @@
                            <ul>
                               <xsl:apply-templates select="$dtd2-attributes">
                                  <xsl:with-param name="compare" select="$dtd1-attributes"/>
+                                 <xsl:sort select="../@name"/>
                               </xsl:apply-templates>
                            </ul>
                         </xsl:when>

--- a/xslt/dtdcompare.xsl
+++ b/xslt/dtdcompare.xsl
@@ -348,7 +348,9 @@
 
                <xsl:if test="/declarations/attributes/attribute/attributeDeclaration[@element = $current-name]">
                   <ul>
-                     <xsl:apply-templates select="/declarations/attributes/attribute/attributeDeclaration[@element = $current-name]"/>
+                     <xsl:apply-templates select="/declarations/attributes/attribute/attributeDeclaration[@element = $current-name]">
+                        <xsl:sort select="../@name"/>
+                     </xsl:apply-templates>
                   </ul>
                </xsl:if>
             </td>
@@ -385,7 +387,9 @@
 
                <xsl:if test="$dtd2/declarations/attributes/attribute/attributeDeclaration[@element = $current-name]">
                   <ul>
-                     <xsl:apply-templates select="$dtd2/declarations/attributes/attribute/attributeDeclaration[@element = $current-name]"/>
+                     <xsl:apply-templates select="$dtd2/declarations/attributes/attribute/attributeDeclaration[@element = $current-name]">
+                        <xsl:sort select="../@name"/>
+                     </xsl:apply-templates>
                   </ul>
                </xsl:if>
             </td>


### PR DESCRIPTION
This pull request adds highlighting to the dtdcompare report so that differences are easier to see.

This screenshot shows highlighting differences in attributes:

![image](https://github.com/user-attachments/assets/37695f55-f7df-48d8-8353-4ea17b3a665b)

This screenshot shows highlighting differences in content models:

![image](https://github.com/user-attachments/assets/dbd44dba-fec1-495e-bed8-16b4b1ee7051)

The logic used to identify differences could probably be improved over the basic approach that is used currently, particularly for comparing content models, but the highlighting is nonetheless useful. 